### PR TITLE
Signup: remove Signup env while retaining Login functionality

### DIFF
--- a/UV-GUIDE.md
+++ b/UV-GUIDE.md
@@ -34,7 +34,7 @@ dependencies = [
 uv sync
 ```
 
-### **3. build assets**
+### **build assets**
 
 Compile and build assets for the project:
 
@@ -42,7 +42,7 @@ Compile and build assets for the project:
 uv run invenio-cli assets build
 ```
 
-### **4. start/destroy Services**
+### **start/destroy Services**
 
 Set up and start required services:
 
@@ -51,7 +51,7 @@ uv run invenio-cli services destroy
 uv run invenio-cli services setup
 ```
 
-### **5. run the app**
+### **run the app**
 
 Start the Invenio application:
 
@@ -66,18 +66,4 @@ issues related to architecture (e.g., `-84 architecture` errors) on macOS system
 ```bash
 export SYSTEM_VERSION_COMPAT=1
 arch -arm64 brew install python
-```
-
-### **recreating virtual env**
-
-```bash
-rm -rf .venv
-uv venv --prompt invenio-v12 && source .venv/bin/activate
-```
-
-### **Notes: for services setup**
-
-```bash
-uv run invenio-cli services destroy
-uv run invenio-cli services setup
 ```

--- a/themes/MUG/invenio.cfg
+++ b/themes/MUG/invenio.cfg
@@ -163,7 +163,7 @@ DATACITE_DATACENTER_SYMBOL = ""
 # ----------------
 # See https://github.com/inveniosoftware/invenio-accounts/blob/master/invenio_accounts/config.py
 ACCOUNTS_LOCAL_LOGIN_ENABLED = True  # enable local login
-SECURITY_REGISTERABLE = True  # local login: allow users to register
+SECURITY_REGISTERABLE = False  # local login: allow users to register
 SECURITY_RECOVERABLE = True  # local login: allow users to reset the password
 SECURITY_CHANGEABLE = True  # local login: allow users to change psw
 # SECURITY_CONFIRMABLE = True  # local login: users can confirm e-mail address
@@ -228,7 +228,6 @@ I18N_LANGUAGES = [("de", _("German"))]
 #INVENIO_THEME_SHOW_FRONTPAGE_INTRO_SECTION=False
 THEME_SHOW_FRONTPAGE_INTRO_SECTION = False
 """Set True for frontpage Intrp."""
-
 
 # Invenio-Override
 # --------------


### PR DESCRIPTION
Modified the template to hide the "Sign up" link when `SECURITY_REGISTERABLE` is `False`.
- Kept "Log in" and "Log out" functionality intact.
- User profile links for authenticated users when `USERPROFILES` is enabled.