### PR TITLE
Restrict global search schema to Research Results (RDM)

### DIFF
--- a/themes/MUG/invenio.cfg
+++ b/themes/MUG/invenio.cfg
@@ -328,7 +328,7 @@ GLOBAL_SEARCH_SCHEMAS = {
         "name_l10n": "Research Result",
     },
 }
-"""Only expose RDM schema in global search."""
+"""Mapping of original schemas for global search, here only RDM schema are shown."""
 
 # ============================================================================
 # Invenio-OAuthclient


### PR DESCRIPTION
only the “Research Result (RDM)” global-search schema configured in the instance MUG