### PR TITLE
Set default publisher to Medical University of Graz

### DIFF
--- a/themes/MUG/invenio.cfg
+++ b/themes/MUG/invenio.cfg
@@ -125,7 +125,7 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
             "link": "https://creativecommons.org/licenses/by/4.0/legalcode",
         }
     ],
-    "publisher": "instance",
+    "publisher": "Medical University of Graz",
 }
 
 APP_RDM_DEPOSIT_FORM_AUTOCOMPLETE_NAMES = 'search' # "search_only" or "off"


### PR DESCRIPTION
The Metadatafield "Publisher" should by default be filled out

MUG: 
Please configurate "Medical University of Graz" as default in the Metadatafield "Publisher"