### PR TITLE
ci: publish official-v13-mug image tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,6 +120,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}-mug
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:official-v13-mug
           labels: ${{ steps.meta.outputs.labels }}
 
 


### PR DESCRIPTION
I want to make Helm use official-v13-mug for worker.