### PR TITLE
mug: restrict community creation

### DIFF
--- a/themes/MUG/invenio.cfg
+++ b/themes/MUG/invenio.cfg
@@ -20,6 +20,7 @@ from invenio_curations.services.permissions import (
     CurationRDMRequestsPermissionPolicy,
 )
 from invenio_rdm_records.services.components import DefaultRecordsComponents
+from invenio_override.permissions import CustomCommunitiesPermissionPolicy
 
 def _(x):  # needed to avoid start time failure with lazy strings
     return x
@@ -261,6 +262,22 @@ REQUESTS_PERMISSION_POLICY = CurationRDMRequestsPermissionPolicy
 # ============================================================================
 CURATIONS_ENABLE_REQUEST_COMMENTS = True
 CURATIONS_COMMENT_TEMPLATE_FILE = "comment-template.html"
+
+# ============================================================================
+# Invenio-Communities - Restrict Community Creation
+# ============================================================================
+OVERRIDE_COMMUNITIES_RESTRICT_CREATION = True
+"""Restrict community creation to administrators.
+
+When True: only admins can create communities.
+When False: any authenticated user can create communities.
+"""
+
+OVERRIDE_COMMUNITIES_CREATE_ROLES = ["community-creator"]
+"""Roles allowed to create communities when OVERRIDE_COMMUNITIES_RESTRICT_CREATION is True."""
+
+COMMUNITIES_PERMISSION_POLICY = CustomCommunitiesPermissionPolicy
+"""Custom permission policy for communities."""
 
 # ============================================================================
 # Extras


### PR DESCRIPTION
MUG Feature:
**- only administrators should be able create new communities. But we would like to have the option to ease up on the restriction, when the repository is running. Restrict the creation of communities to the role administrators. The "New community"-button should be hidden for users without the role administrator.**

![1](https://github.com/user-attachments/assets/15169c7b-ff43-46ce-a36b-a1bc5b1864e8)
![2](https://github.com/user-attachments/assets/2c44af25-4371-48f7-831c-260fadf1654c)
