### PR TITLE
feat: add Keycloak details in CI run

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -75,6 +75,16 @@ jobs:
         if: "${{ github.event.inputs.invenio-override-branch != '' && !startsWith( github.ref, 'refs/tags') }}"
         run: sed -i 's/invenio-override", branch = "main"/invenio-override", branch = "${{ github.event.inputs.invenio-override-branch }}"/g' pyproject.toml
 
+      - name: Set keycloak in invenio.cfg via script
+        run: |
+          source .venv/bin/activate
+          if [[ ${{ !startsWith( github.ref, 'refs/tags') }}]]; then
+            KEYCLOAK_NODE="cyverse"
+          else
+            KEYCLOAK_NODE="meduni"
+          python auth/yaml2py.py --source-filename auth/kc-settings-pool.yaml --dest-filename themes/MUG/invenio.cfg --node $KEYCLOAK_NODE --placeholder "<insert_keycloak_config_via_ci>"
+          deactivate
+
       - name: Relock uv
         run: |
           source .venv/bin/activate

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           source .venv/bin/activate
           if [[ ${{ !startsWith( github.ref, 'refs/tags') }} ]]; then
-            KEYCLOAK_NODE="cyverse"
+            KEYCLOAK_NODE="rdm"
           else
             KEYCLOAK_NODE="meduni"
           fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,10 +78,11 @@ jobs:
       - name: Set keycloak in invenio.cfg via script
         run: |
           source .venv/bin/activate
-          if [[ ${{ !startsWith( github.ref, 'refs/tags') }}]]; then
+          if [[ ${{ !startsWith( github.ref, 'refs/tags') }} ]]; then
             KEYCLOAK_NODE="cyverse"
           else
             KEYCLOAK_NODE="meduni"
+          fi
           python auth/yaml2py.py --source-filename auth/kc-settings-pool.yaml --dest-filename themes/MUG/invenio.cfg --node $KEYCLOAK_NODE --placeholder "<insert_keycloak_config_via_ci>"
           deactivate
 

--- a/auth/kc-settings-pool.yaml
+++ b/auth/kc-settings-pool.yaml
@@ -1,0 +1,15 @@
+cyverse:
+  title: "Cyverse SSO"
+  description: Cyverse SSO
+  base_url: https://keycloak.cyverse.at
+  realm: CyVerse
+  app_key: CYVERSE_KEYCLOAK_APP_CREDENTIALS
+  legacy_url_path: False
+
+meduni:
+  title: Meduni SSO
+  description: Meduni SSO
+  base_url: https://openid.medunigraz.at/
+  realm: invenioRDM
+  app_key: KEYCLOAK_APP_CREDENTIALS
+  legacy_url_path: False

--- a/auth/kc-settings-pool.yaml
+++ b/auth/kc-settings-pool.yaml
@@ -1,10 +1,10 @@
-cyverse:
+rdm:
   title: "Cyverse SSO"
   description: Cyverse SSO
   base_url: https://keycloak.cyverse.at
-  realm: CyVerse
+  realm: rdm
   app_key: CYVERSE_KEYCLOAK_APP_CREDENTIALS
-  legacy_url_path: False
+  legacy_url_path: True
 
 meduni:
   title: Meduni SSO

--- a/auth/yaml2py.py
+++ b/auth/yaml2py.py
@@ -1,0 +1,34 @@
+"""
+Script that injects a given yaml config into arguments of an invenio.cfg class.
+"""
+
+import yaml
+import sys
+import argparse
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--source-filename', type=str, required=True)
+parser.add_argument('--dest-filename', type=str, required=True)
+parser.add_argument('--node', type=str, required=True)
+parser.add_argument('--placeholder', type=str, required=True)
+
+args = parser.parse_args()
+
+auth_config = ""
+with open(args.source_filename) as f:
+    data = yaml.safe_load(f)
+    for key, _ in data.items():
+        if key == args.node:
+            for node_key, val in data[key].items():
+                if isinstance(val, str):
+                    auth_config += f'{node_key}="{val}",\n'
+                else:
+                    auth_config += f'{node_key}={val},\n'
+
+with open(args.dest_filename, "r") as f:
+    config = f.read()
+    config = config.replace(args.placeholder, auth_config)
+
+with open(args.dest_filename, "w") as f:
+    f.write(config)

--- a/themes/MUG/invenio.cfg
+++ b/themes/MUG/invenio.cfg
@@ -392,12 +392,7 @@ GLOBAL_SEARCH_SCHEMAS = {
 # Keycloak configurations
 # ============================================================================
 _keycloak_helper = KeycloakSettingsHelper(
-    title="Meduni SSO",
-    description="Meduni SSO",
-    base_url="https://openid.medunigraz.at/",
-    realm="invenioRDM",
-    app_key="KEYCLOAK_APP_CREDENTIALS",
-    legacy_url_path=False
+    <insert_keycloak_config_via_ci>
 )
 
 OAUTHCLIENT_KEYCLOAK_REALM_URL = _keycloak_helper.realm_url
@@ -407,25 +402,13 @@ OAUTHCLIENT_KEYCLOAK_VERIFY_AUD = True  # whether to verify the audience tag for
 OAUTHCLIENT_KEYCLOAK_AUD = "inveniordm"  # probably the same as the client ID
 OAUTHCLIENT_KEYCLOAK_USER_INFO_FROM_ENDPOINT = True
 
-# Cyverse SSO (commented out – uncomment to re-enable)
-# _cyverse_keycloak_helper = KeycloakSettingsHelper(
-#     title="Cyverse SSO",
-#     description="Cyverse SSO",
-#     base_url="https://keycloak.cyverse.at",
-#     realm="CyVerse",
-#     app_key="CYVERSE_KEYCLOAK_APP_CREDENTIALS",
-# )
-# OAUTHCLIENT_CYVERSE_REALM_URL = _cyverse_keycloak_helper.realm_url
-# OAUTHCLIENT_CYVERSE_USER_INFO_URL = _cyverse_keycloak_helper.user_info_url
-# OAUTHCLIENT_CYVERSE_VERIFY_EXP = True
-# OAUTHCLIENT_CYVERSE_VERIFY_AUD = True
-# OAUTHCLIENT_CYVERSE_AUD = "inveniordm"
-# OAUTHCLIENT_CYVERSE_USER_INFO_FROM_ENDPOINT = True
-
+"""
+Keycloak settings like base_url and realm should be set by CI by replacing for
+the placeholder this instance.
+"""
 
 OAUTHCLIENT_REMOTE_APPS = {
-    "keycloak": _keycloak_helper.remote_app
-    # "cyverse": _cyverse_keycloak_helper.remote_app,
+    "keycloak": _keycloak_helper.remote_app,
 }
 
 ## SET THE CREDENTIALS via .env


### PR DESCRIPTION
Add posibility to inject arguments for **KeycloakSettingsHelper** configuration class from a yaml file to the _invenio.cfg_ in CI via python script. This helps to choose between different keycloak providers without changing the _invenio.cfg_.