### PR TITLE
Enable curations UI on deposit form by including invenio-curations-de…

### DIFF
--- a/Dockerfile.mug
+++ b/Dockerfile.mug
@@ -14,6 +14,8 @@ COPY ./static/ ${INVENIO_INSTANCE_PATH}/static/
 COPY ./translations ${INVENIO_INSTANCE_PATH}/translations/
 COPY ./templates ${INVENIO_INSTANCE_PATH}/templates/
 
+COPY themes/MUG/templates/ ${INVENIO_INSTANCE_PATH}/templates/
+
 # Replace variables.less
 COPY themes/MUG/variables.less /opt/env/lib/python3.12/site-packages/invenio_override/assets/semantic-ui/less/invenio_override/variables.less
 COPY themes/MUG/overrides.less /opt/env/lib/python3.12/site-packages/invenio_override/assets/semantic-ui/less/invenio_override/overrides.less

--- a/themes/MUG/templates/semantic-ui/invenio_app_rdm/records/deposit.html
+++ b/themes/MUG/templates/semantic-ui/invenio_app_rdm/records/deposit.html
@@ -1,0 +1,62 @@
+{%- extends config.BASE_TEMPLATE %}
+
+{%- if community and community.theme and community.theme.enabled %}
+  {%- block css %}
+  {{ super() }}
+  <link rel="stylesheet" type="text/css" href="/communities/{{community.slug}}/community-theme-{{ community.revision_id }}.css">
+  {%- endblock %}
+{%- endif %}
+
+{%- if not record.is_published and record.versions.index and record.versions.index > 1 %}
+  {%- set title = _("New version") %}
+{%- elif not record.is_published %}
+  {%- set title = _("New upload") %}
+{% else %}
+  {%- set title = _("Edit upload") %}
+{%- endif %}
+
+{%- block page_body %}
+
+{%- if community_use_jinja_header %}
+{%- include "invenio_communities/details/header.html" %}
+{%- endif %}
+
+  {%- if record %}
+    <input id="deposits-record" type="hidden" name="deposits-record"
+           value='{{ record | tojson }}'>
+
+    <input id="deposits-record-locked-files" type="hidden"
+           name="deposits-record-locked-files"
+           value='{{ files_locked | tojson }}'>
+  {%- endif %}
+
+  {%- if preselectedCommunity %}
+    <input id="deposits-draft-community" type="hidden" name="deposits-draft-community"
+           value='{{ preselectedCommunity | tojson }}'>
+  {%- endif %}
+
+  {%- if files %}
+    <input id="deposits-record-files" type="hidden" name="deposits-record-files"
+           value='{{ files | tojson }}'>
+  {%- endif %}
+
+  {%- if forms_config %}
+    <input type="hidden" name="deposits-config"
+           value='{{ forms_config | tojson }}'>
+  {%- endif %}
+
+  {%- if permissions %}
+    <input id="deposits-record-permissions" type="hidden"
+           name="deposits-record-permissions"
+           value='{{ permissions | tojson }}'>
+  {%- endif %}
+
+  <div id="deposit-form"></div>
+
+{%- endblock page_body %}
+
+{%- block javascript %}
+  {{ super() }}
+  {{ webpack['invenio-app-rdm-deposit.js'] }}
+  {{ webpack['invenio-curations-deposit.js'] }}
+{%- endblock %}


### PR DESCRIPTION
…posit.js bundle

curations UI on deposit form by including the invenio-curations-deposit.js bundle via an instance-level template override. Added instance/templates/semantic-ui/invenio_app_rdm/records/deposit.html that mirrors the base deposit template but loads both invenio-app-rdm-deposit.js and invenio-curations-deposit.js, this should get the curation polling.

After we need to check: ls /opt/invenio/var/instance/templates/semantic-ui/invenio_app_rdm/records/deposit.html, if the build bundle is present. 