### PR TITLE
Fix: Copy invenio.cfg before webpack create to discover curations ent…

### DIFF
--- a/Dockerfile.mug
+++ b/Dockerfile.mug
@@ -8,6 +8,11 @@ RUN uv sync --frozen
 # to use rspack
 ENV INVENIO_WEBPACKEXT_PROJECT="invenio_assets.webpack:rspack_project"
 
+COPY ./themes/MUG/invenio.cfg ${INVENIO_INSTANCE_PATH}
+
+RUN invenio collect --verbose && invenio webpack create
+
+# Now copy remaining instance files (these can override/extend the discovered bundles)
 COPY ./app_data/ ${INVENIO_INSTANCE_PATH}/app_data/
 COPY ./assets/ ${INVENIO_INSTANCE_PATH}/assets/
 COPY ./static/ ${INVENIO_INSTANCE_PATH}/static/
@@ -15,10 +20,8 @@ COPY ./translations ${INVENIO_INSTANCE_PATH}/translations/
 COPY ./templates ${INVENIO_INSTANCE_PATH}/templates/
 
 # Replace variables.less
-COPY themes/MUG/variables.less /opt/env/lib/python3.12/site-packages/invenio_override/assets/semantic-ui/less/invenio_override/variables.less
-COPY themes/MUG/overrides.less /opt/env/lib/python3.12/site-packages/invenio_override/assets/semantic-ui/less/invenio_override/overrides.less
-
-RUN invenio collect --verbose && invenio webpack create
+COPY ./themes/MUG/variables.less /opt/env/lib/python3.12/site-packages/invenio_override/assets/semantic-ui/less/invenio_override/variables.less
+COPY ./themes/MUG/overrides.less /opt/env/lib/python3.12/site-packages/invenio_override/assets/semantic-ui/less/invenio_override/overrides.less
 
 WORKDIR ${INVENIO_INSTANCE_PATH}/assets
 RUN pnpm install
@@ -36,6 +39,7 @@ COPY --from=builder ${INVENIO_INSTANCE_PATH}/templates ${INVENIO_INSTANCE_PATH}/
 
 WORKDIR ${WORKING_DIR}/src
 COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
+# invenio.cfg already copied in builder stage, but ensure it's in final location
 COPY ./themes/MUG/invenio.cfg ${INVENIO_INSTANCE_PATH}
 RUN chown invenio:invenio .
 


### PR DESCRIPTION
…ry point

in Dockerfile.mug, invenio webpack create was running before the instance config - invenio.cfg was copied, so  Flask app needs the instance config to initialize and discover webpack entry points, so the invenio_curations entry point wasn't found during the webpack build

<img width="882" height="259" alt="Screenshot 2026-01-13 at 22 18 41" src="https://github.com/user-attachments/assets/a5083827-8547-4ab3-b716-d1ddea5dd86a" />
<img width="947" height="67" alt="Screenshot 2026-01-13 at 22 16 33" src="https://github.com/user-attachments/assets/d1249f5c-9494-442a-93e1-43dcad75c5fd" />
