### PR TITLE
fix: build correctly RDM records components

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -266,7 +266,7 @@ JOBS_ADMINISTRATION_ENABLED = True
 # Invenio-Override
 # --------------
 
-# from invenio_override import OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
+# from invenio_override.config import OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
 # RDM_RECORDS_SERVICE_COMPONENTS = OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
 # """Build RDM Service components."""
 

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -266,6 +266,10 @@ JOBS_ADMINISTRATION_ENABLED = True
 # Invenio-Override
 # --------------
 
+# from invenio_override import OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
+# RDM_RECORDS_SERVICE_COMPONENTS = OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
+# """Build RDM Service components."""
+
 # # # LOGO
 # #INVENIO_OVERRIDE_LOGO=images/MUG.svg
 # OVERRIDE_LOGO = "images/MUG.svg"

--- a/themes/MUG/invenio.cfg
+++ b/themes/MUG/invenio.cfg
@@ -242,7 +242,6 @@ NOTIFICATIONS_BUILDERS = {
     **CURATIONS_NOTIFICATIONS_BUILDERS,
 }
 
-RDM_RECORDS_SERVICE_COMPONENTS = DefaultRecordsComponents + [CurationComponent]
 
 REQUESTS_FACETS = {
     "type": {"facet": curations_facets.type, "ui": {"field": "type"}},
@@ -395,6 +394,10 @@ GLOBAL_SEARCH_SCHEMAS = {
     },
 }
 """Mapping of original schemas for global search, here only RDM schema are shown."""
+
+from invenio_override.config import OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
+RDM_RECORDS_SERVICE_COMPONENTS = OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS + [CurationComponent]
+"""Build the RDM Service components. Currently contains invenio-override components (globalsearch) and curation component."""
 
 # ============================================================================
 # Invenio-OAuthclient

--- a/themes/MUG/invenio.cfg
+++ b/themes/MUG/invenio.cfg
@@ -251,7 +251,7 @@ REQUESTS_FACETS = {
 CURATIONS_MODERATION_ROLE = "administration-rdm-records-curation"
 """ID of the Role used for record curation."""
 
-CURATIONS_PRIVILEGED_ROLES = ["administration", "bypass-curation"]
+CURATIONS_PRIVILEGED_ROLES = ["administration", "bypass-curation", "administration-rdm-records-curation"]
 """Roles that are exempted from curation workflow and can publish without request for review."""
 
 RDM_PERMISSION_POLICY = CurationRDMRecordPermissionPolicy

--- a/themes/override-basic/invenio.cfg
+++ b/themes/override-basic/invenio.cfg
@@ -265,7 +265,6 @@ JOBS_ADMINISTRATION_ENABLED = True
 
 # Invenio-Override
 # --------------
-
 # # # LOGO
 # #INVENIO_OVERRIDE_LOGO=images/MUG.svg
 # OVERRIDE_LOGO = "images/MUG.svg"

--- a/themes/override-oer/invenio.cfg
+++ b/themes/override-oer/invenio.cfg
@@ -323,3 +323,7 @@ GLOBAL_SEARCH_SCHEMAS = {
     },
 }
 """Mapping of original schemas for global search."""
+
+from invenio_override import OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
+RDM_RECORDS_SERVICE_COMPONENTS = OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
+"""Build RDM Service components."""

--- a/themes/override-oer/invenio.cfg
+++ b/themes/override-oer/invenio.cfg
@@ -324,6 +324,6 @@ GLOBAL_SEARCH_SCHEMAS = {
 }
 """Mapping of original schemas for global search."""
 
-from invenio_override import OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
+from invenio_override.config import OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
 RDM_RECORDS_SERVICE_COMPONENTS = OVERRIDE_RDM_RECORDS_SERVICE_COMPONENTS
 """Build RDM Service components."""


### PR DESCRIPTION
* previously we were overwriting the RDM_RECORDS_SERVICE_COMPONENTS which we set in invenio-override. therefore we missed the global-search component
* import the base components from invenio-override and set the global variable correctly in all invenio.cfg files