### PR TITLE
Search nav and pnpm/rspack build config 

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -294,6 +294,19 @@ CURATIONS_COMMENT_TEMPLATE_FILE = "comment-template.html"
 
 
 # =============================================================================
+# Flask-WebpackExt — rspack + pnpm
+# =============================================================================
+
+SEARCH_UI_SEARCH_TEMPLATE = "invenio_records_global_search/search/search.html"
+"""Use global search index on the /search (All) page."""
+
+
+
+WEBPACKEXT_PROJECT = "invenio_assets.webpack:rspack_project"
+WEBPACKEXT_NPM_PKG_CLS = "pynpm:PNPMPackage"
+
+
+# =============================================================================
 # Extras
 # =============================================================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ authors = [
 
 dependencies = [
     "invenio-app-rdm[opensearch2]==14.0.0b5.dev6",
-    "uwsgi>=2.0",
+    "uwsgi>=2.0; sys_platform == 'linux'",
+    "pyuwsgi>=2.0; sys_platform == 'darwin'",
     "uwsgitop>=0.11",
     "uwsgi-tools>=1.1.1",
     "setuptools<82",
@@ -54,4 +55,4 @@ profile = "jinja"
 py-modules = []
 
 [tool.uv.sources]
-invenio-override = { git = "https://github.com/tu-graz-library/invenio-override.git", branch = "main" }
+invenio-override = { git = "https://github.com/tu-graz-library/invenio-override", branch = "add-search-nav" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,7 @@ authors = [
 
 dependencies = [
     "invenio-app-rdm[opensearch2]==14.0.0b5.dev6",
-    "uwsgi>=2.0; sys_platform == 'linux'",
-    "pyuwsgi>=2.0; sys_platform == 'darwin'",
+    "uwsgi>=2.0",
     "uwsgitop>=0.11",
     "uwsgi-tools>=1.1.1",
     "setuptools<82",
@@ -55,4 +54,4 @@ profile = "jinja"
 py-modules = []
 
 [tool.uv.sources]
-invenio-override = { git = "https://github.com/tu-graz-library/invenio-override", branch = "add-search-nav" }
+invenio-override = { git = "https://github.com/tu-graz-library/invenio-override", branch = "main" }

--- a/templates/invenio_records_global_search/search/search.html
+++ b/templates/invenio_records_global_search/search/search.html
@@ -1,0 +1,25 @@
+{#
+  Copyright (C) 2020-2026 Graz University of Technology.
+
+  instance is free software; you can redistribute it and/or modify it
+  under the terms of the MIT License; see LICENSE file for more details.
+
+  Overrides: invenio_records_global_search/search/search.html
+  Changes:
+    - Added search_nav above the search app.
+    - Switched /search to use global search index.
+#}
+{%- set title = _("All Resources") %}
+{%- set page_description = _("Search and discover across all research results, publications, and educational resources.") %}
+{%- extends config.GLOBAL_SEARCH_BASE_TEMPLATE %}
+{%- block javascript %}
+  {{ super() }}
+  {{ webpack['invenio-records-global-search-search.js'] }}
+{%- endblock %}
+{%- block page_body %}
+  <div class="ui container">
+    {%- include "invenio_override/search_nav.html" %}
+    <div id="invenio-search-global-search-config"
+         data-invenio-search-config='{{ search_app_global_search_config() | tojson }}'></div>
+  </div>
+{%- endblock page_body %}

--- a/templates/semantic-ui/invenio_app_rdm/users/communities.html
+++ b/templates/semantic-ui/invenio_app_rdm/users/communities.html
@@ -18,7 +18,7 @@
   {% if can_create_community %}
     {# Mobile new community ≤1300px #}
     <div class="dashboard-mobile-action-bar">
-      <a href="{{ url_for('invenio_communities.communities_new') }}"
+      <a href="{{ invenio_url_for('invenio_communities.communities_new') }}"
          class="upload-new-circle"
          title="{{ _('New community') }}">
         <i class="plus icon"></i>
@@ -38,7 +38,7 @@
     <div id="new-community-circle"
          class="upload-new-wrap"
          style="display:none">
-      <a href="{{ url_for('invenio_communities.communities_new') }}"
+      <a href="{{ invenio_url_for('invenio_communities.communities_new') }}"
          class="upload-new-circle"
          title="{{ _('New community') }}">
         <i class="plus icon"></i>

--- a/themes/MUG/templates/comment-template.html
+++ b/themes/MUG/templates/comment-template.html
@@ -1,70 +1,68 @@
 <!DOCTYPE html>
 <html>
-<body>
-    <h3> {{header}} </h3>
-
+  <body>
+    <h3>{{ header }}</h3>
     {% if adds|length > 0 %}
-    <h3>{{ _("Added") }}</h3>
-        <ul>
+      <h3>{{ _("Added") }}</h3>
+      <ul>
         {% for add in adds %}
-            {% set result_items = add.diff[2] %}
-            {% for result in result_items %}
-                {% set field = result[0] %}
-                {% set values = result[1:] %}
-                {% for value in values %}
-                    <li>
-                        <strong>{{ field }}</strong>
-                        <div style="margin-left: 1em;">
-                        <span style="color: green;">New: {{ value|safe }}</span>
-                        </div>
-                    </li>
-                {% endfor %}
-            {% endfor %}
-        {% endfor %}
-        </ul>
-    {% endif %}
-
-    {% if changes|length > 0 %}
-    <h3>{{_("Changed")}}</h3>
-        <ul>
-        {% for change in changes %}
-            {% set result = change.diff[2] %}
-            {% set old = result[0] %}
-            {% set new = result[1] %}
-            <li>
-                <strong>{{ change.diff[1] }}</strong>
+          {% set result_items = add.diff[2] %}
+          {% for result in result_items %}
+            {% set field = result[0] %}
+            {% set values = result[1:] %}
+            {% for value in values %}
+              <li>
+                <strong>{{ field }}</strong>
                 <div style="margin-left: 1em;">
-                <span style="color: red;">Old: {{ old|safe }}</span><br>
-                <span style="color: green;">New: {{ new|safe }}</span>
+                  <span style="color: green;">New: {{ value|safe }}</span>
                 </div>
-            </li>
-        {% endfor %}
-        </ul>
-    {% endif %}
-
-    {% if removes|length > 0 %}
-    <h3>{{ _("Removed") }}</h3>
-        <ul>
-        {% for remove in removes %}
-            {% set result_items = remove.diff[2] %}
-            {% for result in result_items %}
-                {% set values = result[1:] %}
-                {% for value in values %}
-                {% if remove.diff[1] == "metadata" %}
-                    {% set field = result[0] %}
-                {% else %}
-                    {% set field = remove.diff[1] %}
-                {% endif %}
-                    <li>
-                        <strong>{{ field }}</strong>
-                        <div style="margin-left: 1em;">
-                        <span style="color: red;">{{ value|safe }}</span>
-                        </div>
-                    </li>
-                {% endfor %}
+              </li>
             {% endfor %}
+          {% endfor %}
         {% endfor %}
-        </ul>
+      </ul>
     {% endif %}
-</body>
+    {% if changes|length > 0 %}
+      <h3>{{ _("Changed") }}</h3>
+      <ul>
+        {% for change in changes %}
+          {% set result = change.diff[2] %}
+          {% set old = result[0] %}
+          {% set new = result[1] %}
+          <li>
+            <strong>{{ change.diff[1] }}</strong>
+            <div style="margin-left: 1em;">
+              <span style="color: red;">Old: {{ old|safe }}</span>
+              <br>
+              <span style="color: green;">New: {{ new|safe }}</span>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% if removes|length > 0 %}
+      <h3>{{ _("Removed") }}</h3>
+      <ul>
+        {% for remove in removes %}
+          {% set result_items = remove.diff[2] %}
+          {% for result in result_items %}
+            {% set values = result[1:] %}
+            {% for value in values %}
+              {% if remove.diff[1] == "metadata" %}
+                {% set field = result[0] %}
+              {% else %}
+                {% set field = remove.diff[1] %}
+              {% endif %}
+              <li>
+                <strong>{{ field }}</strong>
+                <div style="margin-left: 1em;">
+                  <span style="color: red;">{{ value|safe }}</span>
+                </div>
+              </li>
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </body>
 </html>

--- a/themes/TUG/base/templates/comment-template.html
+++ b/themes/TUG/base/templates/comment-template.html
@@ -1,70 +1,68 @@
 <!DOCTYPE html>
 <html>
-<body>
-    <h3> {{header}} </h3>
-
+  <body>
+    <h3>{{ header }}</h3>
     {% if adds|length > 0 %}
-    <h3>{{ _("Added") }}</h3>
-        <ul>
+      <h3>{{ _("Added") }}</h3>
+      <ul>
         {% for add in adds %}
-            {% set result_items = add.diff[2] %}
-            {% for result in result_items %}
-                {% set field = result[0] %}
-                {% set values = result[1:] %}
-                {% for value in values %}
-                    <li>
-                        <strong>{{ field }}</strong>
-                        <div style="margin-left: 1em;">
-                        <span style="color: green;">New: {{ value|safe }}</span>
-                        </div>
-                    </li>
-                {% endfor %}
-            {% endfor %}
-        {% endfor %}
-        </ul>
-    {% endif %}
-
-    {% if changes|length > 0 %}
-    <h3>{{_("Changed")}}</h3>
-        <ul>
-        {% for change in changes %}
-            {% set result = change.diff[2] %}
-            {% set old = result[0] %}
-            {% set new = result[1] %}
-            <li>
-                <strong>{{ change.diff[1] }}</strong>
+          {% set result_items = add.diff[2] %}
+          {% for result in result_items %}
+            {% set field = result[0] %}
+            {% set values = result[1:] %}
+            {% for value in values %}
+              <li>
+                <strong>{{ field }}</strong>
                 <div style="margin-left: 1em;">
-                <span style="color: red;">Old: {{ old|safe }}</span><br>
-                <span style="color: green;">New: {{ new|safe }}</span>
+                  <span style="color: green;">New: {{ value|safe }}</span>
                 </div>
-            </li>
-        {% endfor %}
-        </ul>
-    {% endif %}
-
-    {% if removes|length > 0 %}
-    <h3>{{ _("Removed") }}</h3>
-        <ul>
-        {% for remove in removes %}
-            {% set result_items = remove.diff[2] %}
-            {% for result in result_items %}
-                {% set values = result[1:] %}
-                {% for value in values %}
-                {% if remove.diff[1] == "metadata" %}
-                    {% set field = result[0] %}
-                {% else %}
-                    {% set field = remove.diff[1] %}
-                {% endif %}
-                    <li>
-                        <strong>{{ field }}</strong>
-                        <div style="margin-left: 1em;">
-                        <span style="color: red;">{{ value|safe }}</span>
-                        </div>
-                    </li>
-                {% endfor %}
+              </li>
             {% endfor %}
+          {% endfor %}
         {% endfor %}
-        </ul>
+      </ul>
     {% endif %}
-</body>
+    {% if changes|length > 0 %}
+      <h3>{{ _("Changed") }}</h3>
+      <ul>
+        {% for change in changes %}
+          {% set result = change.diff[2] %}
+          {% set old = result[0] %}
+          {% set new = result[1] %}
+          <li>
+            <strong>{{ change.diff[1] }}</strong>
+            <div style="margin-left: 1em;">
+              <span style="color: red;">Old: {{ old|safe }}</span>
+              <br>
+              <span style="color: green;">New: {{ new|safe }}</span>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% if removes|length > 0 %}
+      <h3>{{ _("Removed") }}</h3>
+      <ul>
+        {% for remove in removes %}
+          {% set result_items = remove.diff[2] %}
+          {% for result in result_items %}
+            {% set values = result[1:] %}
+            {% for value in values %}
+              {% if remove.diff[1] == "metadata" %}
+                {% set field = result[0] %}
+              {% else %}
+                {% set field = remove.diff[1] %}
+              {% endif %}
+              <li>
+                <strong>{{ field }}</strong>
+                <div style="margin-left: 1em;">
+                  <span style="color: red;">{{ value|safe }}</span>
+                </div>
+              </li>
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </body>
 </html>

--- a/uv.lock
+++ b/uv.lock
@@ -1213,9 +1213,9 @@ name = "instance"
 source = { virtual = "." }
 dependencies = [
     { name = "invenio-app-rdm", extra = ["opensearch2"] },
-    { name = "lxml" },
+    { name = "pyuwsgi", marker = "sys_platform == 'darwin'" },
     { name = "setuptools" },
-    { name = "uwsgi" },
+    { name = "uwsgi", marker = "sys_platform == 'linux'" },
     { name = "uwsgi-tools" },
     { name = "uwsgitop" },
 ]
@@ -1245,6 +1245,7 @@ tug = [
     { name = "invenio-records-marc21" },
     { name = "invenio-saml" },
     { name = "invenio-workflows-tugraz" },
+    { name = "lxml" },
     { name = "repository-cli" },
 ]
 
@@ -1261,19 +1262,20 @@ requires-dist = [
     { name = "invenio-global-search", marker = "extra == 'tug'", specifier = ">=0.3.0" },
     { name = "invenio-imoox", marker = "extra == 'tug'", specifier = ">=0.2.0" },
     { name = "invenio-moodle", marker = "extra == 'tug'", specifier = ">=1.1.3" },
-    { name = "invenio-override", marker = "extra == 'basic'", git = "https://github.com/tu-graz-library/invenio-override.git?branch=main" },
-    { name = "invenio-override", extras = ["lom"], marker = "extra == 'mug'", git = "https://github.com/tu-graz-library/invenio-override.git?branch=main" },
-    { name = "invenio-override", extras = ["lom", "marc21"], marker = "extra == 'tug'", git = "https://github.com/tu-graz-library/invenio-override.git?branch=main" },
+    { name = "invenio-override", marker = "extra == 'basic'", git = "https://github.com/tu-graz-library/invenio-override?branch=add-search-nav" },
+    { name = "invenio-override", extras = ["lom"], marker = "extra == 'mug'", git = "https://github.com/tu-graz-library/invenio-override?branch=add-search-nav" },
+    { name = "invenio-override", extras = ["lom", "marc21"], marker = "extra == 'tug'", git = "https://github.com/tu-graz-library/invenio-override?branch=add-search-nav" },
     { name = "invenio-pure", marker = "extra == 'tug'", specifier = ">=0.1.0" },
     { name = "invenio-records-global-search", marker = "extra == 'tug'", specifier = ">=0.3.5" },
     { name = "invenio-records-lom", marker = "extra == 'tug'", specifier = ">=0.20.1" },
     { name = "invenio-records-marc21", marker = "extra == 'tug'", specifier = ">=0.27.0" },
     { name = "invenio-saml", marker = "extra == 'tug'", specifier = ">=1.0.0" },
     { name = "invenio-workflows-tugraz", marker = "extra == 'tug'", specifier = ">=0.12.0" },
-    { name = "lxml", specifier = "==6.0.2" },
+    { name = "lxml", marker = "extra == 'tug'", specifier = "==6.0.2" },
+    { name = "pyuwsgi", marker = "sys_platform == 'darwin'", specifier = ">=2.0" },
     { name = "repository-cli", marker = "extra == 'tug'", specifier = ">=0.13.0" },
     { name = "setuptools", specifier = "<82" },
-    { name = "uwsgi", specifier = ">=2.0" },
+    { name = "uwsgi", marker = "sys_platform == 'linux'", specifier = ">=2.0" },
     { name = "uwsgi-tools", specifier = ">=1.1.1" },
     { name = "uwsgitop", specifier = ">=0.11" },
 ]
@@ -1986,7 +1988,7 @@ wheels = [
 [[package]]
 name = "invenio-override"
 version = "0.0.7"
-source = { git = "https://github.com/tu-graz-library/invenio-override.git?branch=main#093539c97bc152435f61fca03ccf2158762459bd" }
+source = { git = "https://github.com/tu-graz-library/invenio-override?branch=add-search-nav#59b63705c8467c82cf7033ad8cb976a569694ba7" }
 dependencies = [
     { name = "invenio-global-search" },
     { name = "invenio-rdm-records" },
@@ -3530,6 +3532,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/26/9f1f00a5d021fff16dee3de13d43e5e978f3d58928e129c3a62cf7eb9738/pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812", size = 316214 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319", size = 505474 },
+]
+
+[[package]]
+name = "pyuwsgi"
+version = "2.0.30.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/28/c1fa01c1f7613724e95c9f9f3276d4bdd9dc187b140cd68d50b3079bfe56/pyuwsgi-2.0.30.post1.tar.gz", hash = "sha256:b09a4a462173944f6f1d56f942074db02866e16f39045658fa8b7bec861042f4", size = 877709 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/fb/c815c011e7fe4fa401eef7de2cdd106e919b4e29498a1381c18599228825/pyuwsgi-2.0.30.post1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:057ad7829f7f2358a044547cf3345a4a3a6d5c34630fc78c67d4bd6f3164fc84", size = 639808 },
+    { url = "https://files.pythonhosted.org/packages/7d/a3/b5cec94aa846d964278aa92fe01ec9768b2a20caba83224b2f32d3fca49e/pyuwsgi-2.0.30.post1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:db315664b858eb19ab186dd6c175b9253f82963327ddbe307604ee35b9d7df30", size = 584936 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds search nav to the /search (All) page and switches it to the global search index. Configures pnpm and rspack for faster asset builds. 
 
Links to: https://github.com/tu-graz-library/invenio-override/pull/99

**Note:** After merge and approval, the `branch = "add-search-nav"` reference  > in the instance `pyproject.toml` will be removed 