### PR TITLE
Wipe recreate docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ WORKDIR ${WORKING_DIR}/src
 
 COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 COPY ./invenio.cfg ${INVENIO_INSTANCE_PATH}
-RUN chown invenio:invenio .
+COPY ./themes/TUG/base/wipe_recreate.sh ${INVENIO_INSTANCE_PATH}/wipe_recreate.sh
+RUN chmod +x ${INVENIO_INSTANCE_PATH}/wipe_recreate.sh && chown invenio:invenio .
 
 USER invenio
 

--- a/assets/templates/InvenioRecordsLom.Search/SearchApp.results.jsx
+++ b/assets/templates/InvenioRecordsLom.Search/SearchApp.results.jsx
@@ -1,4 +1,0 @@
-// Copyright (C) 2020-2026 Graz University of Technology.
-// Override LOM search results to use the same UploadsResults component
-// as the RDM uploads dashboard (highlight-background row with count + sort).
-export { UploadsResults as default } from "../../js/invenio_override/UploadsResults";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 
 dependencies = [
     "invenio-app-rdm[opensearch2]==14.0.0b5.dev6",
-    "uwsgi>=2.0; sys_platform == 'linux'",
+    "uwsgi>=2.0",
     "uwsgitop>=0.11",
     "uwsgi-tools>=1.1.1",
     "setuptools<82",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                              
                                                                                                                                                                                                                          
  - Adds `wipe_recreate.sh` to the base `Dockerfile` so the script is                                                                                                                                                  accessible inside the container for all builds                                                                                                                                                                        
  - `Dockerfile.tug` already had it 
  -   - Removes `SearchApp.results.jsx` from instance assets to fix the                                                                                                                                                   failing basic/vanilla Docker builds — the JSX belongs i `invenio-override` and will be added there in invenio overide: #105
  
                                                                                                                                                                                                                          
  ## Test plan                            
                                                                                                                                                                                                                          
  - [ ] Build the base Docker image and verify `wipe_recreate.sh` is                                                                                                                                                 executable at `${INVENIO_INSTANCE_PATH}/wipe_recreate.sh`