### PR TITLE
Run the themes locally

### DIFF
--- a/Dockerfile.basic
+++ b/Dockerfile.basic
@@ -8,6 +8,8 @@ RUN uv sync --frozen
 # to use rspack
 ENV INVENIO_WEBPACKEXT_PROJECT="invenio_assets.webpack:rspack_project"
 
+COPY themes/override-basic/variables.less ${UV_PROJECT_ENVIRONMENT}/lib/python3.14/site-packages/invenio_override/assets/semantic-ui/less/invenio_override/variables.less
+
 COPY ./app_data/ ${INVENIO_INSTANCE_PATH}/app_data/
 COPY ./assets/ ${INVENIO_INSTANCE_PATH}/assets/
 # copy specific assets

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Welcome to your InvenioRDM instance.
 
 ## Version
-This repository is based on InvenioAppRDM version 13.
+This repository is based on InvenioRDM v14. The exact pinned version lives in
+``pyproject.toml`` / ``uv.lock``.
 
 ## Getting started
 
@@ -13,9 +14,9 @@ Make sure you have **invenio-cli** package installed.
 
 Run the following commands to have the instance ready for development:
 ```bash
-invenio-cli packages install . # this installs all packages based on your pyproject.toml dependencies
+uv sync # this installs all packages based on your pyproject.toml dependencies
 # or
-invenio cli packages install .[tug] # if you want to specify optional packages
+uv sync --extra tug # if you want to specify optional packages (basic, tug, mug)
 invenio-cli install symlink
 invenio-cli services setup
 
@@ -27,6 +28,37 @@ invenio-cli run web # 1 terminal
 invenio-cli assets watch # run this to have the UI change done automatically in the running app
 ```
 
+### Run a theme locally (default / TUG / MUG)
+
+The instance ships several looks. `local_theme.sh` does locally what the
+Dockerfiles do for the images: install that theme's `invenio.cfg`, swap the
+theme files into the collected assets and build.
+
+```bash
+uv sync --extra basic && ./local_theme.sh default   # core InvenioRDM look, with our theme on top
+uv sync --extra tug   && ./local_theme.sh TUG       # TU Graz
+uv sync --extra mug   && ./local_theme.sh MUG       # Med Uni Graz
+
+invenio-cli run
+```
+
+| Theme | Config | Look |
+|---|---|---|
+| ``default`` | ``themes/override-basic/invenio.cfg`` | ``themes/override-basic/variables.less`` |
+| ``TUG`` | ``themes/TUG/dev/invenio.cfg`` | shipped by the invenio-override package |
+| ``MUG`` | ``themes/MUG/invenio.cfg`` | ``themes/MUG/variables.less`` |
+
+Good to know:
+
+- the script **replaces** ``invenio webpack buildall`` - do not run that
+  afterwards, it re-runs ``webpack create`` and undoes the theme swap
+- ``uv sync`` is only needed when switching profile, not when you only edited a cfg
+- if a switch looks wrong, run ``invenio webpack clean`` first: ``webpack create``
+  never overwrites files it already collected
+- log in with the local email/password form - the Keycloak button needs
+  credentials that only exist in the deployed images
+- the theme cfgs expect the database URI and search index prefix from
+  environment variables in the images, so the script appends local dev values
 
 ### Start the instance (all containerized)
 
@@ -54,8 +86,10 @@ Following is an overview of the generated files and folders:
 | Name | Description |
 |---|---|
 | ``Dockerfile`` | Dockerfile used to build your application image. |
-| ``Pipfile`` | Python requirements installed via [pipenv](https://pipenv.pypa.io) |
-| ``Pipfile.lock`` | Locked requirements (generated on first install). |
+| ``pyproject.toml`` | Python requirements, installed via [uv](https://docs.astral.sh/uv/). Optional extras select the variant (``basic``, ``tug``, ``mug``). |
+| ``uv.lock`` | Locked requirements. |
+| ``local_theme.sh`` | Local dev helper to run a theme (``default``/``TUG``/``MUG``). |
+| ``themes`` | Per-variant config, look and dependencies. |
 | ``app_data`` | Application data such as vocabularies. |
 | ``assets`` | Web assets (CSS, JavaScript, LESS, JSX templates) used in the Webpack build. |
 | ``docker`` | Example configuration for NGINX and uWSGI. |
@@ -85,10 +119,11 @@ Each image has a correspondent instance _variant_ that a user can choose to depl
 
 | Name | Description |
 |---|---|
-| ``Dockerfile`` | Dockerfile used to build base image, without theme. - no variant, used for local testing. |
-| ``Dockerfile.mug`` | Dockerfile used to build MUG image (Research Results only; no Publications). - variant **mug** | 
-| ``Dockerfile.oer`` | Dockerfile used to build Educational Resources image (OER). - variant **oer** |
-| ``Dockerfile.basic`` | Dockerfile used to base invenio-override image (no OER or Publications) and also base invenio theme (without invenio-override) - variants **basic** and **vanilla** |
+| ``Dockerfile.tug`` | TU Graz image. Built twice, selected by the ``TUG_ENV`` build arg - variants **dev** and **qa** |
+| ``Dockerfile.mug`` | Med Uni Graz image (Research Results and Publications) - variant **mug** |
+| ``Dockerfile.basic`` | Core InvenioRDM behaviour with the invenio-override theme on top - variant **basic** |
+| ``Dockerfile`` | Core InvenioRDM without any theme - variant **vanilla** |
+| ``Dockerfile.oer`` | Educational Resources image (OER) - variant **oer**, not built by CI |
 
 
 ## CI/CD

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -353,28 +353,3 @@ AUDIT_LOGS_ENABLED = True
 # Request comment locking + comment preview limit (v14).
 REQUESTS_LOCKING_ENABLED = True
 REQUESTS_COMMENT_PREVIEW_LIMIT = 10
-
-# ============================================================================
-# LOCAL DEV ONLY
-#
-# Why this is needed for testing: branding (OVERRIDE_*/THEME_*) lives in
-# themes/TUG/<env>/invenio.cfg, which is only loaded inside the Docker image
-# (Dockerfile.tug copies it into the instance path). invenio-config-tugraz also
-# ships these defaults, but invenio-override's config loads *after* it (entry
-# points load alphabetically: ...config_tugraz < ...override) and overwrites
-# them with neutral values.
-#
-# ============================================================================
-import os as _os
-
-_tug_cfg = _os.path.join(
-    _os.path.dirname(_os.path.realpath(__file__)), "themes", "TUG", "dev", "invenio.cfg"
-)
-if _os.path.exists(_tug_cfg):
-    with open(_tug_cfg, encoding="utf-8") as _fh:
-        _tug_src = _fh.read().replace(
-            "<insert_keycloak_config_via_ci>",
-            'title="local", description="local", '
-            'base_url="https://localhost/", realm="local"',
-        )
-    exec(compile(_tug_src, _tug_cfg, "exec"), globals())

--- a/local_theme.sh
+++ b/local_theme.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# local dev only: point the local instance at a theme and build its assets.
+# does what the dockerfiles do - install the theme cfg, swap the look, build.
+#
+#   uv sync --extra basic && ./local_theme.sh default
+#   uv sync --extra tug   && ./local_theme.sh TUG
+#   uv sync --extra mug   && ./local_theme.sh MUG
+#
+# note: this replaces `invenio webpack buildall`, do not run that after.
+# if a switch looks wrong, `invenio webpack clean` first - webpack create
+# never overwrites files it already collected.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+THEME="${1:-TUG}"
+INVENIO="$HERE/.venv/bin/invenio"
+VAR="$HERE/.venv/var/instance"
+LESS_DIR="$VAR/assets/less/invenio_override"
+
+# instance file that imports curations, which only TUG/MUG have
+MAPPING="assets/js/invenio_app_rdm/overridableRegistry/mapping.js"
+
+# ============================================================================
+# what each theme needs: a cfg, and which look files to swap in.
+# TUG has no swaps - the theme package already ships the TUG look.
+# ============================================================================
+CFG="" ; VARIABLES="" ; OVERRIDES="" ; MAPPING_SRC=""
+case "$THEME" in
+  default)
+    CFG="themes/override-basic/invenio.cfg"
+    VARIABLES="themes/override-basic/variables.less"
+    MAPPING_SRC="themes/override-basic/$MAPPING"
+    ;;
+  TUG)
+    CFG="themes/TUG/dev/invenio.cfg"
+    ;;
+  MUG)
+    CFG="themes/MUG/invenio.cfg"
+    VARIABLES="themes/MUG/variables.less"
+    OVERRIDES="themes/MUG/overrides.less"
+    ;;
+  *)
+    echo "usage: $0 default|TUG|MUG" >&2
+    exit 1
+    ;;
+esac
+
+# ============================================================================
+# steps
+# ============================================================================
+
+install_config() {
+  # the theme cfgs expect these from the dockerfile ENV
+  export INVENIO_WEBPACKEXT_PROJECT="invenio_assets.webpack:rspack_project"
+  export INVENIO_WEBPACKEXT_NPM_PKG_CLS="pynpm:PNPMPackage"
+
+  # starts out as a symlink to the root invenio.cfg, so unlink first or we
+  rm -f "$VAR/invenio.cfg"
+  sed 's|<insert_keycloak_config_via_ci>|title="local", description="local", base_url="https://localhost/", realm="local"|' \
+    "$HERE/$CFG" > "$VAR/invenio.cfg"
+
+  # the images get infra from env vars, so the theme cfgs leave it out. TUG/MUG
+  # set no db uri and no search prefix (TUG sets INDEX_PREFIX, which nothing
+  # reads) - without the prefix the frontpage queries `global-search` and 404s.
+  cat >> "$VAR/invenio.cfg" <<'PY'
+
+SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://instance:instance@localhost/instance"
+SEARCH_INDEX_PREFIX = "instance-"
+ACCOUNTS_LOCAL_LOGIN_ENABLED = True
+PY
+}
+
+restore_instance_assets() {
+  # webpack create drops the instance assets (less/theme.config, less/site,
+  # templates), copy them back like the dockerfiles do. a few are symlinked
+  # to the same source, cp complains about those - ignore it.
+  cp -R "$HERE/assets/." "$VAR/assets/" 2>/dev/null || true
+}
+
+apply_look() {
+  # reset to what the theme package ships first: webpack create does not
+  # overwrite what it already collected so otherwise the previous run's
+  # colours stick around.
+  local pkg
+  pkg="$("$HERE/.venv/bin/python" -c 'import invenio_override, os; print(os.path.join(os.path.dirname(invenio_override.__file__), "assets/semantic-ui/less/invenio_override"))')"
+
+  # first, then only ever touch real files inside it.
+  if [ -L "$LESS_DIR" ]; then
+    local real; real="$(cd "$LESS_DIR" && pwd -P)"
+    rm "$LESS_DIR"
+    cp -R "$real" "$LESS_DIR"
+  fi
+
+  # dest may also be a per-file symlink into the package/repo - drop the link
+  # (never the target) before copying, so we always write a real file.
+  swap() {
+    if [ -L "$2" ]; then rm -f "$2"; fi
+    cp "$1" "$2"
+  }
+
+  swap "$pkg/variables.less" "$LESS_DIR/variables.less"
+  swap "$pkg/overrides.less" "$LESS_DIR/overrides.less"
+
+  [ -n "$VARIABLES" ]   && swap "$HERE/$VARIABLES"   "$LESS_DIR/variables.less"
+  [ -n "$OVERRIDES" ]   && swap "$HERE/$OVERRIDES"   "$LESS_DIR/overrides.less"
+  [ -n "$MAPPING_SRC" ] && swap "$HERE/$MAPPING_SRC" "$VAR/$MAPPING"
+  return 0
+}
+
+# ============================================================================
+# run
+# ============================================================================
+echo "==> theme: $THEME"
+
+install_config
+
+"$INVENIO" collect --verbose
+"$INVENIO" webpack create
+
+restore_instance_assets
+apply_look
+
+"$INVENIO" webpack install
+"$INVENIO" webpack build
+
+echo "==> done, now: invenio-cli run"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ tug = [
 mug = [
     "invenio-curations>=0.8.3",
     "invenio-global-search>=0.4.3",
-    "invenio-override[lom] >=1.0.0",
+    "invenio-records-marc21>=0.32.1",
+    "invenio-override[marc21,lom] >=1.0.0",
 ]
 basic = [
     "invenio-override >=1.0.0",

--- a/themes/MUG/overrides.less
+++ b/themes/MUG/overrides.less
@@ -157,7 +157,7 @@ pre {
 /* accordion field titles */
 .ui.accordion.invenio-accordion-field .title {
   background-color: @overridePrimary;
-  color: @ocerridePlabels !important;
+  color: @overrideLabels !important;
 }
 
 /* button styling */
@@ -176,7 +176,7 @@ pre {
 .ui.primary.buttons .button,
 .ui.primary.button {
   background-color: @overridePrimary;
-  color: @ocerridePlabels !important;
+  color: @overrideLabels !important;
   text-shadow: none;
 }
 
@@ -207,7 +207,7 @@ pre {
 .ui.primary.label {
   background-color: @overridePrimary;
   border-color: @overridePrimary;
-  color: @ocerridePlabels;
+  color: @overrideLabels;
 }
 
 #skip-to-main {

--- a/themes/TUG/dev/invenio.cfg
+++ b/themes/TUG/dev/invenio.cfg
@@ -98,8 +98,13 @@ JOBS_ADMINISTRATION_ENABLED = True
 ###
 
 from invenio_config_tugraz.permissions import TUGrazRDMRecordPermissionPolicy
+from invenio_config_tugraz.permissions import TUGrazCommunityPermissionPolicy
 
 RDM_PERMISSION_POLICY = TUGrazRDMRecordPermissionPolicy
+
+# communities follow tugraz_authenticated, not just "signed up". without this
+# the core default applies and any logged in user can create a community.
+COMMUNITIES_PERMISSION_POLICY = TUGrazCommunityPermissionPolicy
 
 
 ###

--- a/themes/TUG/qa/invenio.cfg
+++ b/themes/TUG/qa/invenio.cfg
@@ -98,8 +98,13 @@ JOBS_ADMINISTRATION_ENABLED = True
 ###
 
 from invenio_config_tugraz.permissions import TUGrazRDMRecordPermissionPolicy
+from invenio_config_tugraz.permissions import TUGrazCommunityPermissionPolicy
 
 RDM_PERMISSION_POLICY = TUGrazRDMRecordPermissionPolicy
+
+# communities follow tugraz_authenticated, not just "signed up". without this
+# the core default applies and any logged in user can create a community.
+COMMUNITIES_PERMISSION_POLICY = TUGrazCommunityPermissionPolicy
 
 
 ###

--- a/themes/override-basic/invenio.cfg
+++ b/themes/override-basic/invenio.cfg
@@ -99,11 +99,29 @@ APP_DEFAULT_SECURE_HEADERS = {
 # See https://invenio-theme.readthedocs.io/en/latest/configuration.html
 
 # Name used in header and UI
-THEME_SITENAME = "instance"
+THEME_SITENAME = "InvenioRDM"
 # Frontpage title
-THEME_FRONTPAGE_TITLE = "instance"
+THEME_FRONTPAGE_TITLE = "InvenioRDM"
 # Header logo
 # THEME_LOGO = 'images/invenio-rdm.svg'
+
+
+OVERRIDE_FOOTER_LOGOS = []
+
+OVERRIDE_FOOTER_LINKS = {
+    "InvenioRDM": [
+        {
+            "label": "Documentation",
+            "url": "https://inveniordm.docs.cern.ch/",
+            "external": True,
+        },
+        {
+            "label": "About InvenioRDM",
+            "url": "https://inveniosoftware.org/products/rdm/",
+            "external": True,
+        },
+    ],
+}
 
 
 # Invenio-App-RDM

--- a/themes/override-basic/variables.less
+++ b/themes/override-basic/variables.less
@@ -12,19 +12,16 @@
 
 /* Accessibility-related badge colors */
 @accessRight: @overridePrimary;
-@accessRightOpen: @accessRight;
+@accessRightOpen: #e9711c;
 @accessRightRestricted: #db2828;
 @accessRightEmbargoed: #fbbd08;
 @accessRightClosed: @accessRightEmbargoed;
 @accessRightMetadata: #5e5e5e;
 
-/* Primary colors — Medical University of Graz Green */
-@overridePrimary: #007934;
-@overrideSecondary: #34b233;
+/* primary colors - invenio rdm blue (default look) */
+@overridePrimary: #0377cd;
+@overrideSecondary: #0360a8;
 @overrideLabels: #ffffff;
-
-/* input focus/hover border, used in overrides.less */
-@mugSearch: @overridePrimary;
 @overridePrimaryBt: #dbdce0;
 @hoverOverridePrimaryBt: #bfc0c2;
 @highlightHeaderColor: @overridePrimaryBt;
@@ -146,23 +143,6 @@
 @font-size-lg: 1.25rem; // h3
 @font-size-xl: 1.5rem; // h2
 @font-size-2xl: 2rem; // h1
-
-/* ======================================
-   Message / Notification Colors
-====================================== */
-@msgShadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-
-@msgSuccessBg: #f0faf5;
-@msgSuccessText: #1a6b4a;
-
-@msgInfoBg: #f0f7ff;
-@msgInfoText: #1a5276;
-
-@msgWarningBg: #fffaf3;
-@msgWarningText: #856404;
-
-@msgErrorBg: #fff5f5;
-@msgErrorText: #9b1c1c;
 
 /* ======================================
    Instance Banner Colors

--- a/uv.lock
+++ b/uv.lock
@@ -1205,7 +1205,8 @@ basic = [
 mug = [
     { name = "invenio-curations" },
     { name = "invenio-global-search" },
-    { name = "invenio-override", extra = ["lom"] },
+    { name = "invenio-override", extra = ["lom", "marc21"] },
+    { name = "invenio-records-marc21" },
 ]
 tug = [
     { name = "invenio-alma" },
@@ -1241,11 +1242,12 @@ requires-dist = [
     { name = "invenio-imoox", marker = "extra == 'tug'", specifier = ">=0.2.0" },
     { name = "invenio-moodle", marker = "extra == 'tug'", specifier = ">=1.1.4" },
     { name = "invenio-override", marker = "extra == 'basic'", git = "https://github.com/tu-graz-library/invenio-override?branch=main" },
-    { name = "invenio-override", extras = ["lom"], marker = "extra == 'mug'", git = "https://github.com/tu-graz-library/invenio-override?branch=main" },
+    { name = "invenio-override", extras = ["lom", "marc21"], marker = "extra == 'mug'", git = "https://github.com/tu-graz-library/invenio-override?branch=main" },
     { name = "invenio-override", extras = ["lom", "marc21"], marker = "extra == 'tug'", git = "https://github.com/tu-graz-library/invenio-override?branch=main" },
     { name = "invenio-pure", marker = "extra == 'tug'", specifier = ">=0.1.0" },
     { name = "invenio-records-global-search", marker = "extra == 'tug'", specifier = ">=0.4.0" },
     { name = "invenio-records-lom", marker = "extra == 'tug'", specifier = ">=0.23.0" },
+    { name = "invenio-records-marc21", marker = "extra == 'mug'", specifier = ">=0.32.1" },
     { name = "invenio-records-marc21", marker = "extra == 'tug'", specifier = ">=0.32.1" },
     { name = "invenio-saml", marker = "extra == 'tug'", specifier = ">=1.0.0" },
     { name = "invenio-workflows-tugraz", marker = "extra == 'tug'", specifier = ">=0.12.1" },


### PR DESCRIPTION
Adds `local_theme.sh` so any variant can be run locally, not just TUG. It does
what the Dockerfiles do: installs the theme's `invenio.cfg`, swaps the look files into the collected assets, builds.

```bash
uv sync --extra basic && ./local_theme.sh default
uv sync --extra tug   && ./local_theme.sh TUG
uv sync --extra mug   && ./local_theme.sh MUG

invenio-cli run
```

What's in it

- default now looks like core InvenioRDM  its own variables.less in InvenioRDM blue, proper site name and footer links, no TUG/MUG partner logos
- MUG was broken: two undefined LESS variables made the asset build fail, and marc21 was enabled in the config but never installed, so every page 500'd
- TUG community creation now requires tugraz_authenticated
- invenio.cfg no longer exec's the TUG dev cfg at import time the script handles that for every theme
- README documents all of it

Behaviour changes worth a look

- Users without tugraz_authenticated can no longer create communities on TUG.
TUGrazCommunityPermissionPolicy already existed in invenio-config-tugraz but
was never wired up, so the core default applied and any logged-in user could.
- The default variant's look and footer changed.

TUG and MUG were both tested locally after the change.

### Screenshot - including default 
<img width="1488" height="810" alt="Screenshot 2026-07-20 at 10 48 11" src="https://github.com/user-attachments/assets/b5d3abee-d546-452c-99fb-84b958d2b88c" />
