### PR TITLE
Reinstall invenio-cli after theme build

### DIFF
--- a/local_theme.sh
+++ b/local_theme.sh
@@ -123,4 +123,9 @@ apply_look
 "$INVENIO" webpack install
 "$INVENIO" webpack build
 
+# `uv sync --extra ...` (run before this script) prunes invenio-cli from the
+# venv - it is a dev tool, not a project dependency - so reinstall it here so
+# `invenio-cli run` works afterwards.
+uv pip install --python "$HERE/.venv/bin/python" invenio-cli
+
 echo "==> done, now: invenio-cli run"


### PR DESCRIPTION
 invenio-cli isn't a project dependency, so uv sync --extra … run before local_theme.sh prunes it from the venv so after which invenio-cli run fails and you have to reinstall it by hand.