### PR TITLE
dev: enable debug mode for local development

### DIFF
--- a/run-debug.sh
+++ b/run-debug.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# local dev only: run the dev server WITH the Flask debugger.
+#
+# invenio-cli run can't enable the debugger - it sets FLASK_DEBUG, which this
+# Flask version ignores; only `invenio run --debug` turns it on. this starts
+# the celery worker plus the web server with the debugger active.
+#
+# services must be up first (once):  invenio-cli services setup
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+export INVENIO_INSTANCE_PATH="$HERE/.venv/var/instance"
+
+# celery worker in the background; stopped when this script exits
+"$HERE/.venv/bin/celery" -A invenio_app.celery worker --beat --events \
+  --loglevel INFO --queues celery,low &
+WORKER=$!
+trap 'kill "$WORKER" 2>/dev/null || true' EXIT
+
+# web server with the Flask debugger enable
+"$HERE/.venv/bin/invenio" run --debug \
+  --cert "$HERE/docker/nginx/test.crt" --key "$HERE/docker/nginx/test.key" \
+  --host 127.0.0.1 --port 5000 \
+  --extra-files "$INVENIO_INSTANCE_PATH/invenio.cfg"


### PR DESCRIPTION
* local_theme.sh appends DEBUG = True to the instance cfg
* document INVENIO_DEBUG=True for the plain invenio-cli run flow

<img width="1031" height="381" alt="Screenshot 2026-07-29 at 10 50 06" src="https://github.com/user-attachments/assets/5f313799-9af9-4110-98af-92d14a8705f9" />

invenio-cli run can't enable the Flask debugger it sets FLASK_DEBUG, which this Flask version ignores only invenio run --debug works. Now run-debug.sh runs the worker + web server with --debug so the debugger and auto-reload actually work locally.

